### PR TITLE
Fix version constraints in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^7.3 || ^7.4 || ^8.0 || ^8.1 || ^8.2",
-        "composer/installers": "~1.7"
+        "php": "~7.2.0 || ~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0",
+        "composer/installers": "^1.7 || ^2.2"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.5.5",


### PR DESCRIPTION
From https://github.com/szepeviktor/composer-managed-wordpress/pull/6
